### PR TITLE
feat: adding the classes to set the text properties

### DIFF
--- a/assets/css/_typography.css
+++ b/assets/css/_typography.css
@@ -39,3 +39,19 @@
 	letter-spacing: var(--body-4-letter-spacing);
 	line-height: var(--body-4-line-height);
 }
+
+.bold {
+	font-weight: 700;
+}
+
+.semibold {
+	font-weight: 600;
+}
+
+.medium {
+	font-weight: 500;
+}
+
+.regular {
+	font-weight: 400;
+}

--- a/assets/css/_typography.css
+++ b/assets/css/_typography.css
@@ -1,7 +1,41 @@
-/* TODO: generate the font classes */
+.text-heading-1 {
+	font-size: var(--heading-1-size);
+	letter-spacing: var(--heading-1-letter-spacing);
+	line-height: var(--heading-1-line-height);
+}
+
+.text-heading-2 {
+	font-size: var(--heading-2-size);
+	letter-spacing: var(--heading-2-letter-spacing);
+	line-height: var(--heading-2-line-height);
+}
+
+.text-heading-3 {
+	font-size: var(--heading-3-size);
+	letter-spacing: var(--heading-3-letter-spacing);
+	line-height: var(--heading-3-line-height);
+}
+
+.text-body-1 {
+	font-size: var(--body-1-size);
+	letter-spacing: var(--body-1-letter-spacing);
+	line-height: var(--body-1-line-height);
+}
 
 .text-body-2 {
 	font-size: var(--body-2-size);
 	letter-spacing: var(--body-2-letter-spacing);
 	line-height: var(--body-2-line-height);
+}
+
+.text-body-3 {
+	font-size: var(--body-3-size);
+	letter-spacing: var(--body-3-letter-spacing);
+	line-height: var(--body-3-line-height);
+}
+
+.text-body-4 {
+	font-size: var(--body-4-size);
+	letter-spacing: var(--body-4-letter-spacing);
+	line-height: var(--body-4-line-height);
 }


### PR DESCRIPTION
- Inside _typography.css I added the classes that match the Fonts in [Figma](https://www.figma.com/file/EFlGK158VL4Cphasesw2aS/UI-Design?type=design&node-id=15-2565&mode=design&t=PmYY3apV0TVYR99Z-0)

For example, if you Large/Body-2/Regular like this
<img width="606" alt="Screenshot 2023-10-20 at 2 42 26 PM" src="https://github.com/whamester/WMDD-4885-Project/assets/57273227/ba299888-8ead-4e03-92b1-f75bc4bffbab">

The class for the text should be `text-body-2 bold`, the Large/Small attribute will be given depending on the screen size, so if you are on mobile text-body-2 will be the Smaller version and if you are on desktop it will be the Larger version.
