### PR TITLE
fix: css variables reference

### DIFF
--- a/assets/components/ReportCard.js
+++ b/assets/components/ReportCard.js
@@ -55,8 +55,10 @@ class MyReport extends ReportCard {
 		divInner.setAttribute('class', `report-card__inner`)
 		divInner.innerHTML = `
 		<div class="report-card__heading">
-			<span class="btn__icon">
-				<i class="icon-${this.category}-filled" style="width:24px; height:24px; background-color: white"></i>
+			<span class="btn__icon report-card__heading__icon">
+				<i class="icon-${
+					this.category
+				}-filled" style="width:24px; height:24px; background-color: white"></i>
 			</span>
         	<p class="text-body-1 semibold">${this.hazard}</p>
 		</div>
@@ -92,7 +94,7 @@ class MyReport extends ReportCard {
 		<div class="report-card__spacer-line"></div>
 
 		<div class="report-card__my-reports-buttons">
-			${ ToggleSwitch(this.id) }
+			${ToggleSwitch(this.id)}
 			<button class="btn btn-tertiary text-body-3 medium" id="${this.id}">
 				<i class="icon-edit"></i>
 				Edit Report

--- a/assets/components/ToggleSwitch.js
+++ b/assets/components/ToggleSwitch.js
@@ -17,10 +17,10 @@ export const onToggle = ({ target }) => {
 
 	if (toggleSwitch.checked) {
 		toggleStatus.textContent = 'Ongoing'
-		toggleStatus.style.color = 'var(--success-success-500-base, #10973D)'
+		toggleStatus.style.color = 'var(--success, #10973D)'
 	} else {
 		toggleStatus.textContent = 'Inactive'
-		toggleStatus.style.color = 'var(--warning-warning-700, #AD7311)'
+		toggleStatus.style.color = 'var(--warning-700, #AD7311)'
 	}
 }
 

--- a/assets/css/_global.css
+++ b/assets/css/_global.css
@@ -7,7 +7,6 @@
 
 @import url(./alert-popup.css);
 @import url(./modal.css);
-@import url(./report-card.css);
 @import url(./toggle-switch.css);
 
 :root {

--- a/assets/css/_global.css
+++ b/assets/css/_global.css
@@ -29,7 +29,7 @@ body {
 
 a[class='link'] {
 	font-weight: 700;
-	color: var(--neutral-neutral-700, #344054);
+	color: var(--neutral-700);
 }
 
 i[class^='icon-'] {

--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -50,7 +50,7 @@
 	font-size: var(--body-2-size);
 	letter-spacing: var(--body-2-letter-spacing);
 	line-height: var(--body-2-line-height);
-	color: var(--neutral-neutral-400, #98a2b3);
+	color: var(--neutral-400, #98a2b3);
 }
 
 .form-field .form-field__input-container {

--- a/assets/css/report-card.css
+++ b/assets/css/report-card.css
@@ -19,7 +19,7 @@
 	background: var(--neutral-100, #f0f2f5);
 }
 
-.btn__icon {
+.report-card__heading__icon {
 	background: var(--error-500);
 	width: 24px;
 	height: 24px;

--- a/assets/css/report-card.css
+++ b/assets/css/report-card.css
@@ -1,6 +1,6 @@
 .report-card__outer {
 	border-radius: 0.75rem;
-	border: 1px solid var(--neutral-neutral-300, #d0d5dd);
+	border: 1px solid var(--neutral-300, #d0d5dd);
 	background: var(--white, #fff);
 	box-shadow: 0px 2px 1px 0px rgba(0, 0, 0, 0.05);
 }
@@ -16,7 +16,7 @@
 	flex: 1 0 0;
 	padding: 0.5rem;
 	border-radius: 0.5rem;
-	background: var(--neutral-neutral-100, #f0f2f5);
+	background: var(--neutral-100, #f0f2f5);
 }
 
 .btn__icon {
@@ -74,4 +74,3 @@
 	background: none;
 	border: none;
 }
-

--- a/assets/css/toggle-switch.css
+++ b/assets/css/toggle-switch.css
@@ -27,7 +27,7 @@
 	left: 0;
 	right: 0;
 	bottom: 0;
-	background-color: var(--warning-warning-700, #ad7311);
+	background-color: var(--warning-700, #ad7311);
 	-webkit-transition: 0.4s;
 	transition: 0.4s;
 }
@@ -45,7 +45,7 @@
 }
 
 input:checked + .slider {
-	background-color: var(--success-success-500-base, #10973d);
+	background-color: var(--success-500, #10973d);
 }
 
 input:checked + .slider:before {
@@ -64,5 +64,5 @@ input:checked + .slider:before {
 }
 
 #toggleStatus {
-	color: var(--success-success-500-base, #10973d);
+	color: var(--success, #10973d);
 }

--- a/pages/home/style.css
+++ b/pages/home/style.css
@@ -1,14 +1,16 @@
+@import url(../../assets/css/report-card.css);
+
 #map {
-  width: 100vw;
-  height: 100vh;
+	width: 100vw;
+	height: 100vh;
 }
 
 .search--input {
-  border: none;
-  outline: none;
+	border: none;
+	outline: none;
 }
 
 .btn-tags {
-  width: auto !important;
-  margin-right: 10px;
+	width: auto !important;
+	margin-right: 10px;
 }

--- a/pages/login/style.css
+++ b/pages/login/style.css
@@ -15,7 +15,7 @@
 }
 
 div > p {
-	color: var(--neutral-neutral-500, #667185);
+	color: var(--neutral-500, #667185);
 }
 
 h1 {

--- a/pages/my-reports/style.css
+++ b/pages/my-reports/style.css
@@ -1,4 +1,7 @@
-#recentReports, #olderReports {
+@import url(../../assets/css/report-card.css);
+
+#recentReports,
+#olderReports {
 	display: flex;
 	flex-direction: column;
 	gap: 1.5rem;


### PR DESCRIPTION
Description:
- Fixing some CSS variable names

These are the variables defined in the repository:

```css
	--primary-50: #e9ebeb;
	--primary-100: #bbc1bf;
	--primary-200: #9aa3a1;
	--primary-300: #6c7a76;
	--primary-400: #50605b;
	--primary-500: #243832;
	--primary-600: #21332e;
	--primary-700: #1a2824;
	--primary-800: #141f1c;
	--primary-900: #0f1815;

	--secondary-50: #fbfdfc;
	--secondary-100: #f3f8f6;
	--secondary-200: #edf4f2;
	--secondary-300: #e5efec;
	--secondary-400: #e0ece8;
	--secondary-500: #d8e7e2;
	--secondary-600: #c5d2ce;
	--secondary-700: #99a4a0;
	--secondary-800: #777f7c;
	--secondary-900: #5b615f;

	--accent-50: #fef0ea;
	--accent-100: #fcd0bf;
	--accent-200: #fab9a0;
	--accent-300: #f89875;
	--accent-400: #f7855a;
	--accent-500: #f56631;
	--accent-600: #df5d2d;
	--accent-700: #ae4823;
	--accent-800: #87381b;
	--accent-900: #672b15;

	--error-50: #fbe9e9;
	--error-100: #f2bcba;
	--error-200: #eb9b99;
	--error-300: #e26e6a;
	--error-400: #dd514d;
	--error-500: #d42621;
	--error-600: #c1231e;
	--error-700: #971b17;
	--error-800: #751512;
	--error-900: #59100e;

	--warning-50: #fef6e8;
	--warning-100: #fbe2b7;
	--warning-200: #f9d495;
	--warning-300: #f7c164;
	--warning-400: #f5b546;
	--warning-500: #f3a218;
	--warning-600: #dd9316;
	--warning-700: #ad7311;
	--warning-800: #86590d;
	--warning-900: #66440a;

	--success-50: #e7f5ec;
	--success-100: #b5dfc3;
	--success-200: #91cfa6;
	--success-300: #5fb97d;
	--success-400: #40ac64;
	--success-500: #10973d;
	--success-600: #0f8938;
	--success-700: #0b6b2b;
	--success-800: #095322;
	--success-900: #073f1a;

	--neutral-50: #f7f9fc;
	--neutral-100: #f0f2f5;
	--neutral-200: #e4e7ec;
	--neutral-300: #d0d5dd;
	--neutral-400: #98a2b3;
	--neutral-500: #667185;
	--neutral-600: #475367;
	--neutral-700: #344054;
	--neutral-800: #1d2739;
	--neutral-900: #101928;

	--white: #ffffff;

	--primary: var(--primary-500);
	--secondary: var(--secondary-500);
	--accent: var(--accent-500);
	--warning: var(--warning-500);
	--error: var(--error-500);
```

The main difference is that we don't repeat the color name so you may find for example --neutral-neutral-900 on Figma, but our variable is --neutral-900.
Besides that Design has base colors like --primary-primary-500-base, and for us that would be --primary, so for the colors with suffix of base you can use the shorthand variables we have

```css
        --primary
	--secondary
	--accent
	--warning
	--error
```    


Note: the fallback or default assigned when referencing a variable is okay but first we need to make sure we are targeting the right variable otherwise this color may not be using our color but the fallback.

