### PR TITLE
Whamester/fix 178 hide actions after any of them have been used

### DIFF
--- a/assets/components/HazardDetailCard.js
+++ b/assets/components/HazardDetailCard.js
@@ -126,13 +126,19 @@ class HazardDetailCard extends ReportCardContainer {
   }
 
   changeButtonState() {
-    //If I have already flagged the report
-    if (!!this.flagged_as_fake) {
+    //If I have already flagged the report or if enable reaction is false
+    if (!!this.flagged_as_fake || !this.enable_reaction) {
       // hide the flag report button
       this.divContainer.querySelector('#flagReportBtn').classList.add('hidden');
+      // hide the reaction buttons
+      this.divContainer.querySelector('#stillThereBtn').classList.add('hidden');
+      this.divContainer.querySelector('#notThereBtn').classList.add('hidden');
     } else {
       // show the flag report button
       this.divContainer.querySelector('#flagReportBtn').classList.remove('hidden');
+      // show the reaction buttons
+      this.divContainer.querySelector('#stillThereBtn').classList.remove('hidden');
+      this.divContainer.querySelector('#notThereBtn').classList.remove('hidden');
     }
 
     // If I have flagged the report and others aswell
@@ -155,18 +161,7 @@ class HazardDetailCard extends ReportCardContainer {
     }
     // If the report has not been flagged
     else {
-      this.divContainer.querySelector('#flagReportMessage').classList.add('hidden');
-    }
-
-    // if enable reaction is false
-    if (!this.enable_reaction) {
-      // hide the reaction buttons
-      this.divContainer.querySelector('#stillThereBtn').classList.add('hidden');
-      this.divContainer.querySelector('#notThereBtn').classList.add('hidden');
-    } else {
-      // show the reaction buttons
-      this.divContainer.querySelector('#stillThereBtn').classList.remove('hidden');
-      this.divContainer.querySelector('#notThereBtn').classList.remove('hidden');
+      this.divContainer.querySelector('.report-card__hazard-detail-buttons').classList.add('hidden');
     }
   }
 

--- a/assets/components/HazardDetailCard.js
+++ b/assets/components/HazardDetailCard.js
@@ -139,6 +139,12 @@ class HazardDetailCard extends ReportCardContainer {
       // show the reaction buttons
       this.divContainer.querySelector('#stillThereBtn').classList.remove('hidden');
       this.divContainer.querySelector('#notThereBtn').classList.remove('hidden');
+
+      if (!!this.flagged_count) {
+        this.divContainer.querySelector('.report-card__hazard-detail-buttons').classList.add('hidden');
+      } else {
+        this.divContainer.querySelector('.report-card__hazard-detail-buttons').classList.remove('hidden');
+      }
     }
 
     // If I have flagged the report and others aswell
@@ -159,10 +165,6 @@ class HazardDetailCard extends ReportCardContainer {
       this.divContainer.querySelector('#flagReportMessage').classList.remove('hidden');
       this.divContainer.querySelector('#flagReportMessage p').innerHTML = FLAGGED_BY_OTHERS_MESSAGE;
     }
-    // If the report has not been flagged
-    else {
-      this.divContainer.querySelector('.report-card__hazard-detail-buttons').classList.add('hidden');
-    }
   }
 
   hazardCardContent() {
@@ -173,6 +175,10 @@ class HazardDetailCard extends ReportCardContainer {
     divOuter.setAttribute('class', `report-card__outer`);
     let divInner = document.createElement('div');
     divInner.setAttribute('class', `report-card__inner`);
+
+    const scrollContainer = document.createElement('div');
+    scrollContainer.setAttribute('class', 'report-card__scroll-container');
+    scrollContainer.appendChild(divInner);
 
     divOuter.appendChild(super.getTopControls());
     divInner.appendChild(super.getHeading());
@@ -188,7 +194,7 @@ class HazardDetailCard extends ReportCardContainer {
 
     // TODO: We can add the edit button for the user if it's the author of the report
 
-    divOuter.appendChild(divInner);
+    divOuter.appendChild(scrollContainer);
     divContainer.appendChild(divOuter);
 
     divContainer.querySelector('#stillThereBtn').addEventListener('click', () => {

--- a/assets/components/ReportCardContainer.js
+++ b/assets/components/ReportCardContainer.js
@@ -165,6 +165,7 @@ class ReportCardContainer {
     div.innerHTML = contentHTML;
     return div;
   }
+
   getMyReportButtons() {
     const contentHTML = `	
     ${ToggleSwitch(this.id, !this.deleted_at)}

--- a/assets/components/ReportCardContainer.js
+++ b/assets/components/ReportCardContainer.js
@@ -20,8 +20,8 @@ class ReportCardContainer {
     this.not_there_count = Number(data.not_there_count) || 0;
     this.still_there_count = Number(data.still_there_count) || 0;
 
-    this.flagged_as_fake = data.flagged_as_fake || false;
-    this.enable_reaction = data.enable_reaction || true;
+    this.flagged_as_fake = !!data.flagged_as_fake;
+    this.enable_reaction = !!data.enable_reaction;
 
     this.created_at = data.created_at;
     this.deleted_at = data.deleted_at;

--- a/assets/css/hazard-detail-card.css
+++ b/assets/css/hazard-detail-card.css
@@ -90,7 +90,9 @@
     border-radius: 0.75rem;
     top: 14.3rem;
     left: 5rem;
-    height: 24rem;
+    height: fit-content;
+    max-height: 24rem;
+    overflow: auto;
   }
 
   .report-card__inner {

--- a/assets/css/hazard-detail-card.css
+++ b/assets/css/hazard-detail-card.css
@@ -68,6 +68,10 @@
   flex-grow: 0;
 }
 
+.report-card__scroll-container {
+  max-height: calc(100% - 80px);
+}
+
 @media screen and (min-width: 768px) {
   .report-card__top-controls {
     flex-direction: column;
@@ -91,8 +95,8 @@
     top: 14.3rem;
     left: 5rem;
     height: fit-content;
-    max-height: 24rem;
-    overflow: auto;
+    max-height: max-content;
+    height: fit-content;
   }
 
   .report-card__inner {
@@ -114,5 +118,17 @@
     left: 0;
     z-index: 1;
     background-color: var(--white);
+  }
+
+  .report-card__scroll-container {
+    overflow-y: auto;
+    height: fit-content;
+    max-height: 40vh;
+  }
+}
+
+@media screen and (min-height: 950px) and (min-width: 768px) {
+  .report-card__scroll-container {
+    max-height: max-content;
   }
 }

--- a/assets/css/report-card.css
+++ b/assets/css/report-card.css
@@ -11,12 +11,17 @@
   margin: 1rem;
   display: flex;
   flex-direction: column;
-  height: calc(100% - 2rem);
+  max-height: calc(100% - 2rem);
 }
 
 .report-card__inner > div:not(:first-child):not(:last-child) {
   border-bottom: 1px solid var(--neutral-300, #d0d5dd);
   padding: 1rem 0;
+}
+
+.report-card__inner > div:nth-last-child(1 of :not(.hidden)) {
+  border-bottom: none;
+  padding-bottom: 0;
 }
 
 .report-card__inner > div:nth-child(2) {
@@ -25,6 +30,12 @@
 
 .report-card__inner > div:last-child {
   padding-top: 1rem;
+}
+
+.report-card__inner > .report-card__reported-by {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .report-card__heading {

--- a/assets/css/report-card.css
+++ b/assets/css/report-card.css
@@ -11,7 +11,7 @@
   margin: 1rem;
   display: flex;
   flex-direction: column;
-  max-height: calc(100% - 2rem);
+  /* max-height: calc(100% - 2rem); */
 }
 
 .report-card__inner > div:not(:first-child):not(:last-child) {
@@ -136,4 +136,16 @@
   width: 1.2rem;
   height: 1.2rem;
   background-color: var(--neutral-600);
+}
+
+@media screen and (min-width: 768px) {
+  .report-card__outer {
+    width: 25rem;
+  }
+}
+
+@media screen and (min-width: 1440px) {
+  .report-card__outer {
+    width: 25rem;
+  }
 }

--- a/pages/home/script.js
+++ b/pages/home/script.js
@@ -577,7 +577,9 @@ const showHazardDetails = (hazardReport) => {
 
     let updateHeight = (height) => {
       //updating sheet height
-      content.style.height = `${height}vh`;
+      if (window.matchMedia('(max-width: 768px)').matches) {
+        content.style.height = `${height}vh`;
+      }
     };
 
     function mediaQueryCheck(windowWidth) {

--- a/pages/home/script.js
+++ b/pages/home/script.js
@@ -133,7 +133,7 @@ window.onload = async function () {
       const makerExists = geoMap.checkMarkerOnMap(hazardDetail);
 
       // marker currently doesnot exists on the map
-      if (!makerExists) geoMap.createLayerGroups([{ ...hazardDetail, hazardCategory: hazardDetail.category, hazard: hazardDetail.option }], {...markerParams, focus: true});
+      if (!makerExists) geoMap.createLayerGroups([{ ...hazardDetail, hazardCategory: hazardDetail.category, hazard: hazardDetail.option }], { ...markerParams, focus: true });
 
       flyTo(hazardDetail.location?.lat, hazardDetail.location?.lng);
     }
@@ -281,21 +281,21 @@ const getReportApiCall = async (lat, lng) => {
 };
 
 const changeActiveMarkerIcon = (lat, lng) => {
-  for(const marker of geoMap.mapLayers.getLayers()) {
+  for (const marker of geoMap.mapLayers.getLayers()) {
     const mCoords = marker.getLatLng();
     if (marker.active) {
-      marker.setIcon(Map.createIcon({iconName: marker.icon_name}));
+      marker.setIcon(Map.createIcon({ iconName: marker.icon_name }));
       marker.setZIndexOffset(null);
       marker.active = false;
     }
 
-    if(lat === mCoords.lat && lng === mCoords.lng) {
-      marker.setIcon(Map.createIcon({iconName: marker.icon_name_focused}));
+    if (lat === mCoords.lat && lng === mCoords.lng) {
+      marker.setIcon(Map.createIcon({ iconName: marker.icon_name_focused }));
       marker.setZIndexOffset(1000);
       marker.active = true;
     }
   }
-}
+};
 
 const cardsOnClick = () => {
   document.querySelectorAll('.sb-cards--item').forEach((card) => {
@@ -375,12 +375,17 @@ const injectCards = () => {
 
   injectHTML([{ func: HazardCardLayout, args: hazardCardParams, target: '#hazard-comp' }]);
 
-  document.querySelector('.sb-cards-btn--back').addEventListener('click', () => {
-    document.querySelector('.sb-cards').remove(); document.querySelector('.btn-report-hazard').style.display = 'flex'; 
-    searchInput.dataset.positionChange='false';
-    searchInput.value='';
-    geoMap.setRelativeMarkerOnMap(0, 0, {removeOnly: true});
-  }, false);
+  document.querySelector('.sb-cards-btn--back').addEventListener(
+    'click',
+    () => {
+      document.querySelector('.sb-cards').remove();
+      document.querySelector('.btn-report-hazard').style.display = 'flex';
+      searchInput.dataset.positionChange = 'false';
+      searchInput.value = '';
+      geoMap.setRelativeMarkerOnMap(0, 0, { removeOnly: true });
+    },
+    false
+  );
 
   document.querySelectorAll('.view-details')?.forEach((detailBtn) => {
     detailBtn.addEventListener('click', async ({ target }) => {
@@ -420,7 +425,7 @@ const injectCards = () => {
 const watchGeoLocationSuccess = async ({ coords }) => {
   const lat = coords?.latitude;
   const lng = coords?.longitude;
-  geoMap.setMarkerOnMap(lat, lng, {icon: 'current-location-map-pin.svg'});
+  geoMap.setMarkerOnMap(lat, lng, { icon: 'current-location-map-pin.svg' });
 
   // If there is a report id in the query params and the focus param is set, don't pan to the user's location
   // but to the report's location
@@ -512,7 +517,7 @@ const showHazardDetails = (hazardReport) => {
     root.appendChild(hazardReportPopulated, document.getElementById('hazard-comp'));
 
     const cardBackBtn = document.querySelector('.sb-cards-btn--back');
-    if(cardBackBtn) cardBackBtn.style.display = 'none';
+    if (cardBackBtn) cardBackBtn.style.display = 'none';
 
     loadIcons();
 
@@ -522,34 +527,38 @@ const showHazardDetails = (hazardReport) => {
     const baseUrl = window.location.origin;
     const url = baseUrl + `/pages/home/index.html?id=${hazardReport.id}&focus=true&open=true&zoom=12&lat=${hazardReport.lat}&lng=${hazardReport.lng}`;
 
-    reportShareBtn.addEventListener("click", async () => {
-      try {
-        const dateObj1 = new Date(hazardReport.created_at);
-        const date1 = DateFormat.getDate(dateObj1);
-        const time1 = DateFormat.getTime(dateObj1);
-
-        const dateObj2 = new Date(hazardReport.updated_at);
-        const date2 = DateFormat.getDate(dateObj2);
-        const time2 = DateFormat.getTime(dateObj2);
-
-        const data = {
-          title: hazardReport.hazard,
-          text: `Hazard: ${hazardReport.hazard}\nLocation: ${hazardReport.location}\nReported: ${date1 + ' ' + time1}\nUpdated: ${hazardReport.updated_at ?  date2 + ' ' + time2 : 'N/A'}\n`,
-          url,
-        };
-
-        await navigator.share(data);
-      } catch (err) {
-        console.error('Share error: ', err);
-
+    reportShareBtn.addEventListener(
+      'click',
+      async () => {
         try {
-          await navigator.clipboard.writeText(url);
-          AlertPopup.show('Link Copied!', AlertPopup.success);
+          const dateObj1 = new Date(hazardReport.created_at);
+          const date1 = DateFormat.getDate(dateObj1);
+          const time1 = DateFormat.getTime(dateObj1);
+
+          const dateObj2 = new Date(hazardReport.updated_at);
+          const date2 = DateFormat.getDate(dateObj2);
+          const time2 = DateFormat.getTime(dateObj2);
+
+          const data = {
+            title: hazardReport.hazard,
+            text: `Hazard: ${hazardReport.hazard}\nLocation: ${hazardReport.location}\nReported: ${date1 + ' ' + time1}\nUpdated: ${hazardReport.updated_at ? date2 + ' ' + time2 : 'N/A'}\n`,
+            url,
+          };
+
+          await navigator.share(data);
         } catch (err) {
-          console.error('Clipboard error: ', err);
+          console.error('Share error: ', err);
+
+          try {
+            await navigator.clipboard.writeText(url);
+            AlertPopup.show('Link Copied!', AlertPopup.success);
+          } catch (err) {
+            console.error('Clipboard error: ', err);
+          }
         }
-      }
-    }, false);
+      },
+      false
+    );
 
     const reportCloseBtn = document.getElementById('reportCloseBtn');
     reportCloseBtn.addEventListener('click', () => {

--- a/pages/home/style.css
+++ b/pages/home/style.css
@@ -5,11 +5,7 @@
 @import url(../../assets/css/map-controls.css);
 
 body {
-  margin: 0;
   padding: 0;
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
 }
 
 header {

--- a/pages/my-reports/style.css
+++ b/pages/my-reports/style.css
@@ -9,11 +9,11 @@
   padding-bottom: 1rem;
 }
 
-#olderReports .btn{
+#olderReports .btn {
   pointer-events: none;
 }
 
-.report-card__inner.inactive>div:not(:first-child):not(:last-child) {
+.report-card__inner.inactive > div:not(:first-child):not(:last-child) {
   -webkit-filter: grayscale(1);
 }
 
@@ -85,10 +85,6 @@ input[type='radio'] {
     flex-direction: row;
     flex-wrap: wrap;
   }
-
-  .report-card__outer {
-    width: 25rem;
-  }
 }
 
 @media screen and (min-width: 1440px) {
@@ -102,9 +98,5 @@ input[type='radio'] {
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
-  }
-
-  .report-card__outer {
-    width: 25rem;
   }
 }

--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -181,7 +181,6 @@ self.addEventListener('activate', async (event) => {
 const API_REQUESTS_URLS = ['https://outsafebc-api.netlify.app'];
 const APP_BLACKLIST = ['https://outsafebc-api.netlify.app', '/jawg-terrain', 'chrome-extension://'];
 
-
 self.addEventListener('fetch', (event) => {
   event.respondWith(
     fetch(event.request)


### PR DESCRIPTION
Fix:
- Hazard card flag buttons were still visible after the user hit still there/not there

Feature:
- Hide all the hazard card flag buttons whenever any of these are clicked.