### PR TITLE
Arodriguez/fix 160 icons on hazard category cards don’t have the correct size

### DIFF
--- a/pages/report-hazard/category.css
+++ b/pages/report-hazard/category.css
@@ -27,6 +27,7 @@
   .category-icon{  
   width: 2.5rem;
   height: 2.5rem;
+  padding-left: 1.375rem;
 }
 
 .category-container .text-container {

--- a/pages/report-hazard/category.css
+++ b/pages/report-hazard/category.css
@@ -24,7 +24,7 @@
   padding-top: 0.5rem;
 }
 
-.category-container .category-icon img {
+  .category-icon{  
   width: 2.5rem;
   height: 2.5rem;
 }


### PR DESCRIPTION
"fix: [https://github.com/whamester/WMDD-4885-Project/issues/160](url) issue"