### PR TITLE
Whamester/fix 203 report buttons should be in one row in the detail card

### DIFF
--- a/assets/components/HazardCardLayout.js
+++ b/assets/components/HazardCardLayout.js
@@ -10,7 +10,9 @@ const HazardCardLayout = ({ reports }) => {
 
   return reports
     ? `<div class="sb-cards">
-    <button class="sb-cards-btn--back"></button>
+    <button class="sb-cards-btn--back">
+      <i class="icon-close-square" style="background-color: var(--neutral-500)"></i>
+    </button>
     <div class="sb-cards-outer">
       <div class="sb-cards-header">
         <p class="sb-label-title">Recent Hazards</p>

--- a/assets/components/SearchBar.js
+++ b/assets/components/SearchBar.js
@@ -45,7 +45,7 @@ const SearchBar = ({ categories }) => {
             <div class="sb-suggestion">
               <div class="sb-suggestion-wrapper" style="display:none"></div>
             </div>
-            <div id="hazard-comp"></div>
+            <div id="hazard-comp" class="hidden"></div>
           </div>
           
           <div class="sb-categories">

--- a/assets/css/_global.css
+++ b/assets/css/_global.css
@@ -69,6 +69,10 @@ ul {
   display: none !important;
 }
 
+.no-visible {
+  visibility: hidden !important;
+}
+
 .pointer {
   cursor: pointer;
 }

--- a/assets/css/_variables.css
+++ b/assets/css/_variables.css
@@ -1,220 +1,223 @@
 :root {
-	/* Design Media Queries */
-	--d-mobile: 375px;
-	--d-web: 1440px;
+  /* Design Media Queries */
+  --d-mobile: 375px;
+  --d-web: 1440px;
 
-	/* Typography */
-	--font-size-base: 16px;
+  /* Typography */
+  --font-size-base: 16px;
 
-	/* Desktop [DONT USE DIRECTLY]*/
-	--heading-1-large-size: 40px;
-	--heading-1-large-letter-spacing: -1%;
-	--heading-1-large-line-height: 120%;
+  /* Desktop [DONT USE DIRECTLY]*/
+  --heading-1-large-size: 40px;
+  --heading-1-large-letter-spacing: -1%;
+  --heading-1-large-line-height: 120%;
 
-	--heading-2-large-size: 32px;
-	--heading-2-large-letter-spacing: -1%;
-	--heading-2-large-line-height: 120%;
+  --heading-2-large-size: 32px;
+  --heading-2-large-letter-spacing: -1%;
+  --heading-2-large-line-height: 120%;
 
-	--heading-3-large-size: 24px;
-	--heading-3-large-letter-spacing: -1%;
-	--heading-3-large-line-height: 120%;
+  --heading-3-large-size: 24px;
+  --heading-3-large-letter-spacing: -1%;
+  --heading-3-large-line-height: 120%;
 
-	--body-1-large-size: 18px;
-	--body-1-large-letter-spacing: 0;
-	--body-1-large-line-height: 150%;
+  --body-1-large-size: 18px;
+  --body-1-large-letter-spacing: 0;
+  --body-1-large-line-height: 150%;
 
-	--body-2-large-size: 16px;
-	--body-2-large-letter-spacing: 0;
-	--body-2-large-line-height: 150%;
+  --body-2-large-size: 16px;
+  --body-2-large-letter-spacing: 0;
+  --body-2-large-line-height: 150%;
 
-	--body-3-large-size: 14px;
-	--body-3-large-letter-spacing: 0;
-	--body-3-large-line-height: 150%;
+  --body-3-large-size: 14px;
+  --body-3-large-letter-spacing: 0;
+  --body-3-large-line-height: 150%;
 
-	--body-4-large-size: 12px;
-	--body-4-large-letter-spacing: 0;
-	--body-4-large-line-height: 150%;
+  --body-4-large-size: 12px;
+  --body-4-large-letter-spacing: 0;
+  --body-4-large-line-height: 150%;
 
-	/* Mobile [DONT USE DIRECTLY]*/
-	--heading-1-small-size: 24px;
-	--heading-1-small-letter-spacing: -1%;
-	--heading-1-small-line-height: 120%;
+  /* Mobile [DONT USE DIRECTLY]*/
+  --heading-1-small-size: 24px;
+  --heading-1-small-letter-spacing: -1%;
+  --heading-1-small-line-height: 120%;
 
-	--heading-2-small-size: 20px;
-	--heading-2-small-letter-spacing: -0.75%;
-	--heading-2-small-line-height: 120%;
+  --heading-2-small-size: 20px;
+  --heading-2-small-letter-spacing: -0.75%;
+  --heading-2-small-line-height: 120%;
 
-	--heading-3-small-size: 16px;
-	--heading-3-small-letter-spacing: -0.75%;
-	--heading-3-small-line-height: 120%;
+  --heading-3-small-size: 16px;
+  --heading-3-small-letter-spacing: -0.75%;
+  --heading-3-small-line-height: 120%;
 
-	--body-1-small-size: 16px;
-	--body-1-small-letter-spacing: 0;
-	--body-1-small-line-height: 150%;
+  --body-1-small-size: 16px;
+  --body-1-small-letter-spacing: 0;
+  --body-1-small-line-height: 150%;
 
-	--body-2-small-size: 14px;
-	--body-2-small-letter-spacing: 0;
-	--body-2-small-line-height: 150%;
+  --body-2-small-size: 14px;
+  --body-2-small-letter-spacing: 0;
+  --body-2-small-line-height: 150%;
 
-	--body-3-small-size: 12px;
-	--body-3-small-letter-spacing: 0;
-	--body-3-small-line-height: 150%;
+  --body-3-small-size: 12px;
+  --body-3-small-letter-spacing: 0;
+  --body-3-small-line-height: 150%;
 
-	/* Headings [USE THESE INSTEAD]*/
-	--heading-1-size: var(--heading-1-large-size);
-	--heading-1-letter-spacing: var(--heading-1-large-letter-spacing);
-	--heading-1-line-height: var(--heading-1-large-line-height);
+  /* Headings [USE THESE INSTEAD]*/
+  --heading-1-size: var(--heading-1-large-size);
+  --heading-1-letter-spacing: var(--heading-1-large-letter-spacing);
+  --heading-1-line-height: var(--heading-1-large-line-height);
 
-	--heading-2-size: var(--heading-2-large-size);
-	--heading-2-letter-spacing: var(--heading-2-large-letter-spacing);
-	--heading-2-line-height: var(--heading-2-large-line-height);
+  --heading-2-size: var(--heading-2-large-size);
+  --heading-2-letter-spacing: var(--heading-2-large-letter-spacing);
+  --heading-2-line-height: var(--heading-2-large-line-height);
 
-	--heading-3-size: var(--heading-3-large-size);
-	--heading-3-letter-spacing: var(--heading-3-large-letter-spacing);
-	--heading-3-line-height: var(--heading-3-large-line-height);
+  --heading-3-size: var(--heading-3-large-size);
+  --heading-3-letter-spacing: var(--heading-3-large-letter-spacing);
+  --heading-3-line-height: var(--heading-3-large-line-height);
 
-	/* Body [USE THESE INSTEAD]*/
-	--body-1-size: var(--body-1-large-size);
-	--body-1-letter-spacing: var(--body-1-large-letter-spacing);
-	--body-1-line-height: var(--body-1-large-line-height);
+  /* Body [USE THESE INSTEAD]*/
+  --body-1-size: var(--body-1-large-size);
+  --body-1-letter-spacing: var(--body-1-large-letter-spacing);
+  --body-1-line-height: var(--body-1-large-line-height);
 
-	--body-2-size: var(--body-2-large-size);
-	--body-2-letter-spacing: var(--body-2-large-letter-spacing);
-	--body-2-line-height: var(--body-2-large-line-height);
+  --body-2-size: var(--body-2-large-size);
+  --body-2-letter-spacing: var(--body-2-large-letter-spacing);
+  --body-2-line-height: var(--body-2-large-line-height);
 
-	--body-3-size: var(--body-3-large-size);
-	--body-3-letter-spacing: var(--body-3-large-letter-spacing);
-	--body-3-line-height: var(--body-3-large-line-height);
+  --body-3-size: var(--body-3-large-size);
+  --body-3-letter-spacing: var(--body-3-large-letter-spacing);
+  --body-3-line-height: var(--body-3-large-line-height);
 
-	--body-4-size: var(--body-4-large-size);
-	--body-4-letter-spacing: var(--body-4-large-letter-spacing);
-	--body-4-line-height: var(--body-4-large-line-height);
+  --body-4-size: var(--body-4-large-size);
+  --body-4-letter-spacing: var(--body-4-large-letter-spacing);
+  --body-4-line-height: var(--body-4-large-line-height);
 
-	/* Colors */
+  /* Colors */
 
-	--primary-50: #e9ebeb;
-	--primary-100: #bbc1bf;
-	--primary-200: #9aa3a1;
-	--primary-300: #6c7a76;
-	--primary-400: #50605b;
-	--primary-500: #243832;
-	--primary-600: #21332e;
-	--primary-700: #1a2824;
-	--primary-800: #141f1c;
-	--primary-900: #0f1815;
+  --primary-50: #e9ebeb;
+  --primary-100: #bbc1bf;
+  --primary-200: #9aa3a1;
+  --primary-300: #6c7a76;
+  --primary-400: #50605b;
+  --primary-500: #243832;
+  --primary-600: #21332e;
+  --primary-700: #1a2824;
+  --primary-800: #141f1c;
+  --primary-900: #0f1815;
 
-	--secondary-50: #fbfdfc;
-	--secondary-100: #f3f8f6;
-	--secondary-200: #edf4f2;
-	--secondary-300: #e5efec;
-	--secondary-400: #e0ece8;
-	--secondary-500: #d8e7e2;
-	--secondary-600: #c5d2ce;
-	--secondary-700: #99a4a0;
-	--secondary-800: #777f7c;
-	--secondary-900: #5b615f;
+  --secondary-50: #fbfdfc;
+  --secondary-100: #f3f8f6;
+  --secondary-200: #edf4f2;
+  --secondary-300: #e5efec;
+  --secondary-400: #e0ece8;
+  --secondary-500: #d8e7e2;
+  --secondary-600: #c5d2ce;
+  --secondary-700: #99a4a0;
+  --secondary-800: #777f7c;
+  --secondary-900: #5b615f;
 
-	--accent-50: #fef0ea;
-	--accent-100: #fcd0bf;
-	--accent-200: #fab9a0;
-	--accent-300: #f89875;
-	--accent-400: #f7855a;
-	--accent-500: #f56631;
-	--accent-600: #df5d2d;
-	--accent-700: #ae4823;
-	--accent-800: #87381b;
-	--accent-900: #672b15;
+  --accent-50: #fef0ea;
+  --accent-100: #fcd0bf;
+  --accent-200: #fab9a0;
+  --accent-300: #f89875;
+  --accent-400: #f7855a;
+  --accent-500: #f56631;
+  --accent-600: #df5d2d;
+  --accent-700: #ae4823;
+  --accent-800: #87381b;
+  --accent-900: #672b15;
 
-	--error-50: #fbe9e9;
-	--error-100: #f2bcba;
-	--error-200: #eb9b99;
-	--error-300: #e26e6a;
-	--error-400: #dd514d;
-	--error-500: #d42621;
-	--error-600: #c1231e;
-	--error-700: #971b17;
-	--error-800: #751512;
-	--error-900: #59100e;
+  --error-50: #fbe9e9;
+  --error-100: #f2bcba;
+  --error-200: #eb9b99;
+  --error-300: #e26e6a;
+  --error-400: #dd514d;
+  --error-500: #d42621;
+  --error-600: #c1231e;
+  --error-700: #971b17;
+  --error-800: #751512;
+  --error-900: #59100e;
 
-	--warning-50: #fef6e8;
-	--warning-100: #fbe2b7;
-	--warning-200: #f9d495;
-	--warning-300: #f7c164;
-	--warning-400: #f5b546;
-	--warning-500: #f3a218;
-	--warning-600: #dd9316;
-	--warning-700: #ad7311;
-	--warning-800: #86590d;
-	--warning-900: #66440a;
+  --warning-50: #fef6e8;
+  --warning-100: #fbe2b7;
+  --warning-200: #f9d495;
+  --warning-300: #f7c164;
+  --warning-400: #f5b546;
+  --warning-500: #f3a218;
+  --warning-600: #dd9316;
+  --warning-700: #ad7311;
+  --warning-800: #86590d;
+  --warning-900: #66440a;
 
-	--success-50: #e7f5ec;
-	--success-100: #b5dfc3;
-	--success-200: #91cfa6;
-	--success-300: #5fb97d;
-	--success-400: #40ac64;
-	--success-500: #10973d;
-	--success-600: #0f8938;
-	--success-700: #0b6b2b;
-	--success-800: #095322;
-	--success-900: #073f1a;
+  --success-50: #e7f5ec;
+  --success-100: #b5dfc3;
+  --success-200: #91cfa6;
+  --success-300: #5fb97d;
+  --success-400: #40ac64;
+  --success-500: #10973d;
+  --success-600: #0f8938;
+  --success-700: #0b6b2b;
+  --success-800: #095322;
+  --success-900: #073f1a;
 
-	--neutral-50: #f7f9fc;
-	--neutral-100: #f0f2f5;
-	--neutral-200: #e4e7ec;
-	--neutral-300: #d0d5dd;
-	--neutral-400: #98a2b3;
-	--neutral-500: #667185;
-	--neutral-600: #475367;
-	--neutral-700: #344054;
-	--neutral-800: #1d2739;
-	--neutral-900: #101928;
+  --neutral-50: #f7f9fc;
+  --neutral-100: #f0f2f5;
+  --neutral-200: #e4e7ec;
+  --neutral-300: #d0d5dd;
+  --neutral-400: #98a2b3;
+  --neutral-500: #667185;
+  --neutral-600: #475367;
+  --neutral-700: #344054;
+  --neutral-800: #1d2739;
+  --neutral-900: #101928;
 
-	--white: #ffffff;
+  --white: #ffffff;
 
-	--primary: var(--primary-500);
-	--secondary: var(--secondary-500);
-	--accent: var(--accent-500);
-	--warning: var(--warning-500);
-	--error: var(--error-500);
+  --primary: var(--primary-500);
+  --secondary: var(--secondary-500);
+  --accent: var(--accent-500);
+  --warning: var(--warning-500);
+  --error: var(--error-500);
 
-	--shadow-xs: 0px 1px 2px 0px rgba(16, 24, 40, 0.05);
+  --shadow-xs: 0px 1px 2px 0px rgba(16, 24, 40, 0.05);
 
-	--padding-x: 5rem
+  --padding-x: 5rem;
+
+  --hazard-container-top: 14.3rem;
+  --hazard-panel-width: 28.6rem;
 }
 
 @media screen and (max-width: 768px) {
-	:root {
-		/* Headings */
-		--heading-1-size: var(--heading-1-small-size);
-		--heading-1-letter-spacing: var(--heading-1-small-letter-spacing);
-		--heading-1-line-height: var(--heading-1-small-line-height);
+  :root {
+    /* Headings */
+    --heading-1-size: var(--heading-1-small-size);
+    --heading-1-letter-spacing: var(--heading-1-small-letter-spacing);
+    --heading-1-line-height: var(--heading-1-small-line-height);
 
-		--heading-2-size: var(--heading-2-small-size);
-		--heading-2-letter-spacing: var(--heading-2-small-letter-spacing);
-		--heading-2-line-height: var(--heading-2-small-line-height);
+    --heading-2-size: var(--heading-2-small-size);
+    --heading-2-letter-spacing: var(--heading-2-small-letter-spacing);
+    --heading-2-line-height: var(--heading-2-small-line-height);
 
-		--heading-3-size: var(--heading-3-small-size);
-		--heading-3-letter-spacing: var(--heading-3-small-letter-spacing);
-		--heading-3-line-height: var(--heading-3-small-line-height);
+    --heading-3-size: var(--heading-3-small-size);
+    --heading-3-letter-spacing: var(--heading-3-small-letter-spacing);
+    --heading-3-line-height: var(--heading-3-small-line-height);
 
-		/* Body */
-		--body-1-size: var(--body-1-small-size);
-		--body-1-letter-spacing: var(--body-1-small-letter-spacing);
-		--body-1-line-height: var(--body-1-line-height);
+    /* Body */
+    --body-1-size: var(--body-1-small-size);
+    --body-1-letter-spacing: var(--body-1-small-letter-spacing);
+    --body-1-line-height: var(--body-1-line-height);
 
-		--body-2-size: var(--body-2-small-size);
-		--body-2-letter-spacing: var(--body-2-small-letter-spacing);
-		--body-2-line-height: var(--body-2-line-height);
+    --body-2-size: var(--body-2-small-size);
+    --body-2-letter-spacing: var(--body-2-small-letter-spacing);
+    --body-2-line-height: var(--body-2-line-height);
 
-		--body-3-size: var(--body-3-small-size);
-		--body-3-letter-spacing: var(--body-3-small-letter-spacing);
-		--body-3-line-height: var(--body-3-small-line-height);
+    --body-3-size: var(--body-3-small-size);
+    --body-3-letter-spacing: var(--body-3-small-letter-spacing);
+    --body-3-line-height: var(--body-3-small-line-height);
 
-		/* There is no body-4-small variant */
-		--body-4-size: var(--body-3-small-size);
-		--body-4-letter-spacing: var(--body-3-small-letter-spacing);
-		--body-4-line-height: var(--body-3-small-line-height);
+    /* There is no body-4-small variant */
+    --body-4-size: var(--body-3-small-size);
+    --body-4-letter-spacing: var(--body-3-small-letter-spacing);
+    --body-4-line-height: var(--body-3-small-line-height);
 
-		--padding-x: 1rem
-	}
+    --padding-x: 1rem;
+  }
 }

--- a/assets/css/hazard-card.css
+++ b/assets/css/hazard-card.css
@@ -15,15 +15,13 @@
   background-color: var(--white);
   padding: 7px 15px 7px 5px;
   color: var(--neutral-900);
+  width: 2.125rem;
+  height: 2.125rem;
 }
 
-.sb-cards-btn--back::before {
-  content: url(/assets/icons/chevron-left.svg);
-}
-
-.sb-cards-btn--back::after {
-  margin-top: -1.5px;
-  content: 'Back';
+.sb-cards-btn--back i.icon-close-square {
+  width: 1.25rem;
+  height: 1.25rem;
 }
 
 .sb-cards {
@@ -53,7 +51,7 @@
   font-style: normal;
   font-weight: 600;
   font-size: var(--body-1-size);
-  line-height: 1.6875rem
+  line-height: 1.6875rem;
 }
 
 .sb-label-count {
@@ -121,36 +119,18 @@
 
   #hazard-comp {
     position: absolute;
-    top: 8.7rem;
+    top: var(--hazard-container-top);
     left: var(--padding-x);
-    width: 410px;
+    width: var(--hazard-panel-width);
   }
 
   .sb-cards-btn--back {
-    display: flex;
     position: absolute;
-    top: 0;
-    right: -45px;
+    top: 1px;
+    right: -46px;
     justify-content: center;
     align-items: center;
     padding: 0;
-    width: 2rem;
-    height: 2rem;
-  }
-
-  .sb-cards-btn--back::before {
-    content: '';
-  }
-
-  .sb-cards-btn--back {
-    background-image: url(/assets/icons/close-square.svg);
-    background-position: center center;
-    background-size: 1.2rem 1.2rem;
-    background-repeat: no-repeat;
-  }
-
-  .sb-cards-btn--back::after {
-    content: '';
   }
 
   .sb-cards {
@@ -162,9 +142,9 @@
     border-radius: 0.75rem;
     background-color: var(--white);
     padding: 1rem;
-    width: calc(410px - 2rem);
     height: 22rem;
     overflow: hidden;
+    border: 1px solid var(--white);
   }
 
   .sb-cards--gradient {
@@ -172,7 +152,7 @@
     position: absolute;
     bottom: 0;
     left: 0;
-    background: linear-gradient(0deg, #FFF 0%, rgba(255, 255, 255, 0.00) 120.13%);
+    background: linear-gradient(0deg, #fff 0%, rgba(255, 255, 255, 0) 120.13%);
     width: calc(100% - 3rem);
     height: 4.8125rem;
     pointer-events: none;
@@ -188,7 +168,7 @@
   }
 
   .sb-cards--item {
-    width: calc(410px - 4rem - 16px);
+    width: calc(var(--hazard-panel-width) - 4rem - 16px);
     height: auto;
   }
 

--- a/assets/css/hazard-detail-card.css
+++ b/assets/css/hazard-detail-card.css
@@ -93,9 +93,10 @@
   #hazard-card__outer {
     position: absolute;
     top: 14.3rem;
-    left: 5rem;
+    left: var(--padding-x);
     border-radius: 0.75rem;
-    width: 410px;
+    max-width: 28.6rem;
+    width: 100%;
     height: fit-content;
     max-height: max-content;
   }

--- a/assets/css/hazard-detail-card.css
+++ b/assets/css/hazard-detail-card.css
@@ -92,10 +92,10 @@
 
   #hazard-card__outer {
     position: absolute;
-    top: 14.3rem;
+    top: var(--hazard-container-top);
     left: var(--padding-x);
     border-radius: 0.75rem;
-    max-width: 28.6rem;
+    max-width: var(--hazard-panel-width);
     width: 100%;
     height: fit-content;
     max-height: max-content;

--- a/assets/css/modal-filter.css
+++ b/assets/css/modal-filter.css
@@ -157,7 +157,7 @@
     transition: none;
     border-radius: 0.75rem;
     padding: 1rem;
-    width: calc(410px - 32px);
+    width: calc(var(--hazard-panel-width) - 32px);
     height: 22rem;
   }
 
@@ -170,18 +170,18 @@
     display: block;
     position: absolute;
     top: 1px;
-    right: -45px;
+    right: -46px;
     cursor: pointer;
     border: 1px solid var(--neutral-300);
     border-radius: 6.25rem;
     background-image: url(/assets/icons/close-square.svg);
     background-position: center center;
-    background-size: 1.2rem 1.2rem;
+    background-size: 1.25rem 1.25rem;
     background-repeat: no-repeat;
     background-color: var(--white);
     padding: 0;
-    width: 2rem;
-    height: 2rem;
+    width: 2.125rem;
+    height: 2.125rem;
   }
 
   .modal-filter--top {

--- a/assets/css/modal-filter.css
+++ b/assets/css/modal-filter.css
@@ -25,7 +25,7 @@
 
 .checkbox label {
   font-style: normal;
-  line-height: 1.5rem
+  line-height: 1.5rem;
 }
 
 .modal-filter--wrapper-outer {
@@ -95,7 +95,7 @@
   position: fixed;
   bottom: 0;
   left: 0;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.00) 0%, #FFF 100%);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, #fff 100%);
   width: 100%;
 }
 
@@ -150,7 +150,7 @@
 @media only screen and (min-width: 768px) {
   .modal-filter {
     position: absolute;
-    top: 14.3rem;
+    top: var(--hazard-container-top);
     left: 5rem;
     z-index: 4;
     animation: none;
@@ -196,14 +196,13 @@
   .modal-filter--bottom {
     position: absolute;
   }
-  
+
   .modal-filter--bottom-wrapper {
     border-bottom-right-radius: 0.75rem;
     border-bottom-left-radius: 0.75rem;
     background-color: var(--white);
   }
 }
-
 
 @keyframes modalFilterAnimation {
   from {

--- a/assets/css/searchbar.css
+++ b/assets/css/searchbar.css
@@ -203,6 +203,7 @@
 @media only screen and (min-width: 768px) {
   .sb {
     top: 90px;
+    left: var(--padding-x);
   }
 
   .sb,
@@ -219,7 +220,7 @@
 
   .sb-wrapper-inner {
     padding: 0;
-    width: 490px;
+    width: 28.6rem;
   }
 
   .sb-suggestion-wrapper,
@@ -239,9 +240,14 @@
 
   .sb-search {
     padding-right: 0;
+    padding-left: 0;
   }
 
   .sb-categories-wrapper {
     margin: auto;
+  }
+
+  .sb-categories {
+    padding-left: 0;
   }
 }

--- a/assets/css/searchbar.css
+++ b/assets/css/searchbar.css
@@ -220,7 +220,7 @@
 
   .sb-wrapper-inner {
     padding: 0;
-    width: 28.6rem;
+    width: var(--hazard-panel-width);
   }
 
   .sb-suggestion-wrapper,

--- a/pages/home/script.js
+++ b/pages/home/script.js
@@ -143,6 +143,8 @@ window.onload = async function () {
       }, 500);
     });
 
+    root.appendChild(document.getElementById('hazard-comp'));
+
     geoMap.map.on('zoomend', ({ target }) => {
       setPrevCenter({
         zoom: target._zoom,
@@ -223,7 +225,9 @@ window.onload = async function () {
 const toggleFilterModal = async (flag) => {
   // close hazard details card
   const reportCloseBtn = document.getElementById('reportCloseBtn');
-  if (reportCloseBtn) reportCloseBtn.click();
+  if (reportCloseBtn) {
+    reportCloseBtn.click();
+  }
 
   const filterModal = document.querySelector('.modal-filter');
   filterModal.classList.toggle('hidden', flag);
@@ -384,7 +388,9 @@ const suggestionOnClick = () => {
     card.addEventListener('click', async ({ target }) => {
       // close hazard details card
       const reportCloseBtn = document.getElementById('reportCloseBtn');
-      if (reportCloseBtn) reportCloseBtn.click();
+      if (reportCloseBtn) {
+        reportCloseBtn.click();
+      }
 
       const suggestionItem = target.closest('.sb-suggestion-item');
 
@@ -454,6 +460,11 @@ const injectCards = () => {
     hazardCardParams.reports = reports;
   }
 
+  const hazardComp = document.getElementById('hazard-comp');
+  if (hazardComp) {
+    hazardComp.classList.remove('hidden');
+  }
+
   injectHTML([{ func: HazardCardLayout, args: hazardCardParams, target: '#hazard-comp' }]);
 
   document.querySelector('.sb-cards-btn--back').addEventListener(
@@ -464,6 +475,11 @@ const injectCards = () => {
       searchInput.dataset.positionChange = 'false';
       searchInput.value = '';
       geoMap.setRelativeMarkerOnMap(0, 0, { removeOnly: true });
+
+      const hazardComp = document.querySelector('#hazard-comp');
+      if (hazardComp) {
+        hazardComp.classList.add('hidden');
+      }
     },
     false
   );
@@ -592,6 +608,16 @@ async function getHazardReportData(id) {
 const showHazardDetails = (hazardReport) => {
   try {
     toggleFilterModal(true);
+    // Disable body scroll when the pull-up card is open
+    const body = document.getElementById('home-body');
+    body.style.overflowY = 'hidden';
+
+    // Hide the search results when a hazard detail is open
+    const searchResultList = document.querySelector('.sb-cards-outer');
+    if (searchResultList) {
+      searchResultList.classList.add('no-visible');
+    }
+
     hazardReportPopulated = hazardReport.hazardCardContent();
 
     root.appendChild(document.getElementById('hazard-comp'));
@@ -650,6 +676,12 @@ const showHazardDetails = (hazardReport) => {
       if (cardBackBtn) cardBackBtn.style.display = 'flex';
       changeActiveMarkerIcon(0, 0);
       clearUrlParams();
+
+      // Show the search results when the hazard detail closes
+      const searchResultList = document.querySelector('.sb-cards-outer');
+      if (searchResultList) {
+        searchResultList.classList.remove('no-visible');
+      }
     });
 
     //
@@ -740,6 +772,18 @@ const showHazardDetails = (hazardReport) => {
             if (cardBackBtn) cardBackBtn.style.display = 'flex';
             changeActiveMarkerIcon(0, 0);
             clearUrlParams();
+
+            // Enable body scroll when the pull-up card is close
+            // This will allow the users to refresh when scroll down
+            const body = document.getElementById('home-body');
+            body.style.overflowY = 'auto';
+
+            //HERE
+            // Show the search results when the hazard detail closes
+            const searchResultList = document.querySelector('.sb-cards-outer');
+            if (searchResultList) {
+              searchResultList.classList.remove('no-visible');
+            }
           }
         };
         const hazardContent = document.querySelector('#hazard-card__outer');

--- a/pages/home/style.css
+++ b/pages/home/style.css
@@ -24,6 +24,9 @@ header {
 #map {
   position: relative;
   width: 100vw;
-  height: 100vh;
   height: 100dvh;
+}
+
+#root {
+  overflow-y: hidden;
 }

--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -1,7 +1,7 @@
-const STATIC_RESOURCES_KEY = 'static-resources-6';
-const APP_RESOURCES_KEY = 'app-resources-6';
+const STATIC_RESOURCES_KEY = 'static-resources-7';
+const APP_RESOURCES_KEY = 'app-resources-7';
 
-const API_REQUESTS_KEY = 'api-requests-6';
+const API_REQUESTS_KEY = 'api-requests-7';
 
 const ICONS = [
   'assets/icons/search.svg',


### PR DESCRIPTION
I have changed the width of the card containers on the homepage, this leaves more space for the hazard actions to be inlined. There where several containers needing the same width so I declared a CSS variable.

While doing these changes I had to fix an issue with the hazard-comp container, this was blocking the markers on the map, so I set the default state to hidden

```
            <div id="hazard-comp" class="hidden"></div>

```
and toggle this class on/off when the container is needed.

fixes #228
